### PR TITLE
Update action to run on merge, and build on runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,17 +25,7 @@ jobs:
       run: yarn build
 
     - name: Package docusaurus build
-      run: tar -xzvf build
-
-    - name: Update docusaurus (live)
-      uses: appleboy/ssh-action@master
-      with:
-        host: 46.101.58.33
-        username: fourier
-        key: ${{ secrets.SSH_MARTY_FOURIER }}
-        port: 22
-        script: |
-            /usr/bin/ansible-pull -U https://${{ secrets.GH_USER_PASS }}:x-oauth-basic@github.com/fourieraudio/webserver.git -t docusaurus_update
+      run: tar -xzvf build.tar.gz build
 
     - name: Send build to marty
       uses: appleboy/scp-action@master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Package docusaurus build
       run: |
         cd build
-        tar -czvf "build.tar.gz"
+        ls
 
     # - name: Send build to marty
     #   uses: appleboy/scp-action@master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
 
-name: Deploy Docs
+name: Deploy Docs to Marty
 
 on:
   push:
@@ -11,7 +11,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  BuildAndMakeLive:
     name: Build
     runs-on: ubuntu-latest
     steps:
@@ -23,9 +23,6 @@ jobs:
 
     - name: Build docusaurus
       run: yarn build
-    #
-    # - name: Package docusaurus build
-    #   run: tar -czvf "build.tar.gz" "/home/runner/work/docs/docs/build"
 
     - name: Send build to marty
       uses: appleboy/scp-action@master
@@ -36,3 +33,13 @@ jobs:
         key: ${{ secrets.SSH_MARTY_FOURIER }}
         source: "/home/runner/work/docs/docs/build"
         target: "/home/fourier"
+
+    - name: Copy to live docusaurus docusaurus directory
+      uses: appleboy/ssh-action@master
+      with:
+        host: 46.101.58.33
+        username: fourier
+        key: ${{ secrets.SSH_MARTY_FOURIER }}
+        port: 22
+        script: |
+          cp /home/github/workspace/build/* /var/www/docusaurus/live

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       run: yarn build
 
     - name: Package docusaurus build
-      run: ls
+      run: tar -czvf "build.tar.gz" -C "/build"
 
     # - name: Send build to marty
     #   uses: appleboy/scp-action@master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,4 +35,4 @@ jobs:
         port: 22
         key: ${{ secrets.SSH_MARTY_FOURIER }}
         source: "/home/runner/work/docs/docs/build"
-        target: "/var/www/docusaurus"
+        target: "/home/fourier"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,7 @@ jobs:
       run: yarn build
 
     - name: Package docusaurus build
-      run: |
-        cd build
-        ls
+      run: tar -czvf "build.tar.gz" "/home/runner/work/docs/docs/build"
 
     # - name: Send build to marty
     #   uses: appleboy/scp-action@master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       run: yarn build
 
     - name: Package docusaurus build
-      run: pwd
+      run: tar -czvf "build.tar.gz" -C "/home/runner/work/docs/docs/build"
 
     # - name: Send build to marty
     #   uses: appleboy/scp-action@master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,12 +27,12 @@ jobs:
     - name: Package docusaurus build
       run: tar -czvf "build.tar.gz" "/home/runner/work/docs/docs/build"
 
-    # - name: Send build to marty
-    #   uses: appleboy/scp-action@master
-    #   with:
-    #     host: 46.101.58.33
-    #     username: fourier
-    #     port: 22
-    #     key: ${{ secrets.SSH_MARTY_FOURIER }}
-    #     source: "build.tar.gz"
-    #     target: "/var/www/docusaurus"
+    - name: Send build to marty
+      uses: appleboy/scp-action@master
+      with:
+        host: 46.101.58.33
+        username: fourier
+        port: 22
+        key: ${{ secrets.SSH_MARTY_FOURIER }}
+        source: "build.tar.gz"
+        target: "/var/www/docusaurus"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,9 +23,9 @@ jobs:
 
     - name: Build docusaurus
       run: yarn build
-
-    - name: Package docusaurus build
-      run: tar -czvf "build.tar.gz" "/home/runner/work/docs/docs/build"
+    #
+    # - name: Package docusaurus build
+    #   run: tar -czvf "build.tar.gz" "/home/runner/work/docs/docs/build"
 
     - name: Send build to marty
       uses: appleboy/scp-action@master
@@ -34,5 +34,5 @@ jobs:
         username: fourier
         port: 22
         key: ${{ secrets.SSH_MARTY_FOURIER }}
-        source: "build.tar.gz"
+        source: "/home/runner/work/docs/docs/build"
         target: "/var/www/docusaurus"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,4 +42,4 @@ jobs:
         key: ${{ secrets.SSH_MARTY_FOURIER }}
         port: 22
         script: |
-          cp -r /home/github/workspace/build/* /var/www/docusaurus/live
+          sudo cp -r /home/fourier/github/workspace/build/* /var/www/docusaurus/live

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       run: yarn build
 
     - name: Package docusaurus build
-      run: tar -czvf "build.tar.gz" -C "/build"
+      run: pwd
 
     # - name: Send build to marty
     #   uses: appleboy/scp-action@master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,4 +42,4 @@ jobs:
         key: ${{ secrets.SSH_MARTY_FOURIER }}
         port: 22
         script: |
-          cp /home/github/workspace/build/* /var/www/docusaurus/live
+          cp -r /home/github/workspace/build/* /var/www/docusaurus/live

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,10 @@
+
 name: Deploy Docs
 
 on:
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+    branches:
+      - main
 
   workflow_dispatch:
 
@@ -15,6 +15,18 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
+    - name: Fetch repo
+      uses: actions/checkout@v2
+
+    - name: Install docusaurus
+      run: yarn install
+
+    - name: Build docusaurus
+      run: yarn build
+
+    - name: Package docusaurus build
+      run: tar -xzvf build
+
     - name: Update docusaurus (live)
       uses: appleboy/ssh-action@master
       with:
@@ -23,4 +35,14 @@ jobs:
         key: ${{ secrets.SSH_MARTY_FOURIER }}
         port: 22
         script: |
-          /usr/bin/ansible-pull -U https://${{ secrets.GH_USER_PASS }}:x-oauth-basic@github.com/fourieraudio/webserver.git -t docusaurus_update
+            /usr/bin/ansible-pull -U https://${{ secrets.GH_USER_PASS }}:x-oauth-basic@github.com/fourieraudio/webserver.git -t docusaurus_update
+
+    - name: Send build to marty
+      uses: appleboy/scp-action@master
+      with:
+        host: 46.101.58.33
+        username: fourier
+        port: 22
+        key: ${{ secrets.SSH_MARTY_FOURIER }}
+        source: "build.tar.gz"
+        target: "/var/www/docusaurus"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,8 +25,8 @@ jobs:
       run: yarn build
 
     - name: Package docusaurus build
-      run: tar -xzvf build.tar.gz build
-
+      run: tar -czvf "build.tar.gz" -C "build"
+      
     - name: Send build to marty
       uses: appleboy/scp-action@master
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,9 @@ jobs:
       run: yarn build
 
     - name: Package docusaurus build
-      run: tar -czvf "build.tar.gz" -C "/home/runner/work/docs/docs/build"
+      run: |
+        cd build
+        tar -czvf "build.tar.gz"
 
     # - name: Send build to marty
     #   uses: appleboy/scp-action@master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,14 +25,14 @@ jobs:
       run: yarn build
 
     - name: Package docusaurus build
-      run: tar -czvf "build.tar.gz" -C "build"
-      
-    - name: Send build to marty
-      uses: appleboy/scp-action@master
-      with:
-        host: 46.101.58.33
-        username: fourier
-        port: 22
-        key: ${{ secrets.SSH_MARTY_FOURIER }}
-        source: "build.tar.gz"
-        target: "/var/www/docusaurus"
+      run: ls
+
+    # - name: Send build to marty
+    #   uses: appleboy/scp-action@master
+    #   with:
+    #     host: 46.101.58.33
+    #     username: fourier
+    #     port: 22
+    #     key: ${{ secrets.SSH_MARTY_FOURIER }}
+    #     source: "build.tar.gz"
+    #     target: "/var/www/docusaurus"


### PR DESCRIPTION
This PR updates the GitHub action to firstly run only when a PR is merged, and also to build the docusaurus site on the runner before uploading to Marty. This is due to the limited RAM resource on Marty at time of writing. 