### PR TITLE
Local IO selection

### DIFF
--- a/docs/rewind/getting-started.md
+++ b/docs/rewind/getting-started.md
@@ -44,10 +44,12 @@ place.
 
 3. Start *Fourier Rewind* and behold the wondrously lime splash screen. Magical.
 
-4. *Rewind* will have started by connecting to your system default audio interface. This will almost
+4. *Rewind* will have started by connecting to your system default audio interface.  This will almost
    certainly not be the interface that your show audio is on, so to select the correct interface,
    select the ![cog](/img/rewind/ui-cog.png) Cog button to open the configuration pane, and select
    the correct interface for your system. Click the big red button, and *Rewind* will come back
    connected to your show audio! Congrats, you now have time travel!
+
+**NB. when first running Fourier Rewind, ensure that the system default audio interface selected in System Preferences is the local IO (ie. 'MacBook Pro Microphone' and 'MacBook Pro Speaker' if on a MacBook Pro laptop). This is a bug with Jack that we are looking to resolve in a future release.**
 
 ![Configuration Interface](/img/rewind/ui-config.png)

--- a/docs/rewind/release_notes.md
+++ b/docs/rewind/release_notes.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 ---
 
 # Release Notes


### PR DESCRIPTION
As per RW-256 - add to the documentation a note to say that when first running Rewind, it is important to ensure that the local IO is selected as the local microphone and speaker. This way Jack loads successfully, allowing the user to configure accordingly. This is a temporary fix.