### PR TITLE
Publish v1.0.1 release notes

### DIFF
--- a/docs/downloads/index.md
+++ b/docs/downloads/index.md
@@ -33,9 +33,10 @@ compatibility ranges at any time.</small>
 
 # Releases
 
-| Engine Version | Compatible Client Version | Release Date | Latest | Release Notes        |
+| Engine Version | Compatible Client Version | Release Date | Latest |                      |
 | -------------- | ------------------------- | ------------ | ------ | -------------------- |
-| 1.0.0          | 1.0.0                     | 22/04/2024   | Yes    | [Click here](v1-0-0) |
+| 1.0.0          | 1.0.0                     | 22/04/2024   |        | [Release notes](v1-0-0) |
+| "              | 1.0.1                     | 22/04/2024   | Yes    | [Release notes](v1-0-1) |
 
 :::note
 

--- a/docs/downloads/v1-0-1.md
+++ b/docs/downloads/v1-0-1.md
@@ -1,0 +1,55 @@
+---
+sidebar_label: Release Notes v1.0.1
+---
+
+# transform.engine v1.0.1 release notes
+
+- **Engine Version**: `1.0.0`
+- **Windows Client Version**: `1.0.1`
+- **macOS Client Version**: `1.0.1`
+
+## New In This Release
+This is a bugfix patch release; for details of the newest features, see [v1.0.0](v1-0-0)!
+
+## Bugs Fixed In This Release
+1. **TF-1682: Engines running release `v0.0.9`, `v0.0.10` fail to offer upgrade automatically**
+
+   We discovered that devices which left the factory running certain older versions could fail to
+   offer the upgrade to the user when using the `v1.0.0` client, resulting in the system upgrade
+   not being possible and the system not functioning correctly. This release fixes this so the
+   upgrade is offered to all users when necessary.
+
+We recommend that all users upgrade to this release.
+
+## Compatibility Changes
+
+This release introduces no compatibility changes: **transform**.client `v1.0.1` is fully compatible
+with **transform**.engine `v1.0.0`.
+
+## Known Issues
+
+Users should be aware of the following [known issues](../manual/known-issues) in this release, which we hope to address in a future update:
+* TF-944: Dante Secondary interface is only operational when using DHCP or Static IP addressing
+* TF-1345: Chain metering freezes whilst that chain restarts
+* TF-1673: Engine service status indicators are occasionally inaccurate
+
+A small number of plugins may experience compatibility issues running on transform.engine.
+For details, see our plugin compatibility database at https://plugins.fourieraudio.com .
+
+## Docs, Support & Bug Requests
+
+We would warmly welcome any bug reports you may have on our discussion site:
+https://discourse.fourieraudio.com . We’ll also be happy to chat and answer any questions you may
+have there!
+
+To learn more about how to use transform.engine, please check out our docs at
+https://docs.fourieraudio.com , where you can also find handy walkthrough videos showing how to get
+started.
+
+If you need support with transform.engine, please feel free to reach out to your local dealer or
+distributor, or contact us directly at support@fourieraudio.com .
+
+## Upcoming Release Schedule
+
+We are hoping to release transform.engine v1.1 in the next 4-8 weeks. For information on what’s
+coming up, see our product roadmap here: https://go.fourieraudio.com/future .


### PR DESCRIPTION
This commit publishes the release notes for **transform**.client `v1.0.1`.