### PR TITLE
Reinstate TF-1673

### DIFF
--- a/docs/downloads/v1-0-0.md
+++ b/docs/downloads/v1-0-0.md
@@ -26,6 +26,7 @@ Users should be aware of the following [known issues](../manual/known-issues) in
 
 - TF-944: Dante Secondary interface is only operational when using DHCP or Static IP addressing
 - TF-1345: Chain metering freezes whilst that chain restarts
+- TF-1673: Engine service status indicators are occasionally inaccurate
 - TF-1686: Connecting the client to the **transform**.engine using a link-local address results in the client not functioning as expected
 
 A small number of plugins may experience compatibility issues running on transform.engine.


### PR DESCRIPTION
This reinstates known issue TF-1673 that was accidentally removed in the last PR.