### PR TITLE
FA-591: enforce trailing slash configuration

### DIFF
--- a/docs/downloads/index.md
+++ b/docs/downloads/index.md
@@ -35,8 +35,8 @@ compatibility ranges at any time.</small>
 
 | Engine Version | Compatible Client Version | Release Date | Latest |                      |
 | -------------- | ------------------------- | ------------ | ------ | -------------------- |
-| 1.0.0          | 1.0.0                     | 22/04/2024   |        | [Release notes](v1-0-0) |
-| "              | 1.0.1                     | 22/04/2024   | Yes    | [Release notes](v1-0-1) |
+| 1.0.0          | 1.0.0                     | 22/04/2024   |        | [Release notes](v1-0-0.md) |
+| "              | 1.0.1                     | 22/04/2024   | Yes    | [Release notes](v1-0-1.md) |
 
 :::note
 

--- a/docs/downloads/v1-0-0.md
+++ b/docs/downloads/v1-0-0.md
@@ -22,7 +22,7 @@ sidebar_label: Release Notes v1.0.0
 
 ## Known Issues
 
-Users should be aware of the following [known issues](../manual/known-issues) in this release, which we hope to address in a future update:
+Users should be aware of the following [known issues](../manual/known-issues.md) in this release, which we hope to address in a future update:
 
 - TF-944: Dante Secondary interface is only operational when using DHCP or Static IP addressing
 - TF-1345: Chain metering freezes whilst that chain restarts

--- a/docs/downloads/v1-0-1.md
+++ b/docs/downloads/v1-0-1.md
@@ -10,7 +10,7 @@ sidebar_label: Release Notes v1.0.1
 
 ## New In This Release
 
-This is a bugfix patch release; for details of the newest features, see [v1.0.0](v1-0-0)!
+This is a bugfix patch release; for details of the newest features, see [v1.0.0](v1-0-0.md)!
 
 ## Bugs Fixed In This Release
 
@@ -30,7 +30,7 @@ with **transform**.engine `v1.0.0`.
 
 ## Known Issues
 
-Users should be aware of the following [known issues](../manual/known-issues) in this release, which we hope to address in a future update:
+Users should be aware of the following [known issues](../manual/known-issues.md) in this release, which we hope to address in a future update:
 
 - TF-944: Dante Secondary interface is only operational when using DHCP or Static IP addressing
 - TF-1345: Chain metering freezes whilst that chain restarts

--- a/docs/intro/faq.md
+++ b/docs/intro/faq.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 This page features some commonly asked questions regarding the **transform**.engine. 
 
-You might like to check out the [spec sheet](hardware-specifications)!
+You might like to check out the [spec sheet](./hardware-specifications.md)!
 
 ### What will I need in order to get started with the **transform**.engine?
 
@@ -31,7 +31,7 @@ You can control the **transform**.engine with a computer running either Windows 
 ### What plugins can I run?
 
 The **transform**.engine supports Windows VST3 plugins that can be installed and activated offline.
-For more info see our [plugin compatibility database](/plugin-database).
+For more info see our [plugin compatibility database](../plugin-database.md).
 
 ### How many plugins can I run?
 

--- a/docs/legacy/rewind/intro.mdx
+++ b/docs/legacy/rewind/intro.mdx
@@ -12,17 +12,17 @@ peruse the FAQs or take a read of the manual.
 The latest version of Fourier Rewind can be downloaded for macOS by clicking here:
 <a class="button button--lg button--primary" href="https://downloads.fourieraudio.com/rewind/latest/FourierRewind-Latest.zip">Download Rewind</a>
 
-The release notes for this release (as well as previous ones) can be found [here](release_notes).
+The release notes for this release (as well as previous ones) can be found [here](release_notes.md).
 
 ## FAQs
 
 All of the commonly asked questions regarding Fourier Rewind can be found here:
-<a class="button button--lg button--primary" href="/docs/legacy/rewind/faq">Rewind FAQs</a>
+<a class="button button--lg button--primary" href="/legacy/rewind/faq">Rewind FAQs</a>
 
 ## Manual
 
 The full interactive Fourier Rewind manual can be found here:
-<a class="button button--lg button--primary" href="/docs/legacy/rewind/manual/intro">Rewind Manual</a>
+<a class="button button--lg button--primary" href="/legacy/rewind/manual/intro">Rewind Manual</a>
 
 ## Something Else?
 

--- a/docs/legacy/rewind/manual/channel-edit-pane.md
+++ b/docs/legacy/rewind/manual/channel-edit-pane.md
@@ -11,7 +11,7 @@ Rewind main interface.
 The channel edit pane can be used to configure the channels in your show.
 
 Each channel can optionally be labelled and have a colour assigned. If assigned,
-they will be shown in the [Channel Selection Region](channel-selection-region):
+they will be shown in the [Channel Selection Region](channel-selection-region.md):
 ![Channel Selection Button with label and colour](/img/rewind/ui-channel-button.png).
 
 You can copy and paste channel name data directly into *Rewind* from your favourite

--- a/docs/legacy/rewind/manual/channel-selection-region.md
+++ b/docs/legacy/rewind/manual/channel-selection-region.md
@@ -11,7 +11,7 @@ When a channel is selected, its audio will be sent to the outputs. Additionally,
 monitors each channel, and the selection button shows the configured colour and label.
 
 The channel selection region automatically expands to the number of channels enabled by the
-[licence](licensing) you have purchased. The screenshot shows a 32-channel configuration, with
+[licence](licensing.md) you have purchased. The screenshot shows a 32-channel configuration, with
 channels 2 and 3 currently selected.
 
 ## Signal Indicators

--- a/docs/legacy/rewind/manual/configuration-pane.md
+++ b/docs/legacy/rewind/manual/configuration-pane.md
@@ -9,10 +9,10 @@ Rewind main interface.
 The configuration pane allows you to configure two types of setting:
 
 * **System Settings**: These are local to your computer, and relate to the particular audio
-  configuration of that machine. They are not saved in your [showfile](showfiles).
+  configuration of that machine. They are not saved in your [showfile](showfiles.md).
 
 * **User Settings**: These are settings that relate to how you want Rewind to act, and are not
-  specific to a given computer. They are saved into your [showfile](showfiles).
+  specific to a given computer. They are saved into your [showfile](showfiles.md).
 
 Use the tabs to navigate between the two types of setting.
 

--- a/docs/legacy/rewind/manual/getting-started.md
+++ b/docs/legacy/rewind/manual/getting-started.md
@@ -24,7 +24,7 @@ place.
   Make sure you have enough RAM for the number of channels, sample rate, and amount of time travel
   you desire: 16 GiB is recommended as a _minimum_, and large systems or systems running at high
   sample rates should have 32 GiB. The amount of RAM that Rewind will use can be
-  [configured](configuration-pane) to taste.
+  [configured](configuration-pane.md) to taste.
 
 - **An almost fanatical devotion to Rewind**: For reliable show-critical audio playback with
   demanding configurations (over 2/3 of system RAM used by *Rewind*), quit any other applications
@@ -42,7 +42,7 @@ place.
    reasonable terms, and, assuming you do, make a brand shining new entry in your Applications
    folder: "*Fourier Rewind*".
 
-3. If your default input and output audio devices aren't the same, make sure they can both run at the same sample rate, or select the system's local IO as the default device instead (in macOS *System Preferences*). See [Troubleshooting](troubleshooting) for further information.
+3. If your default input and output audio devices aren't the same, make sure they can both run at the same sample rate, or select the system's local IO as the default device instead (in macOS *System Preferences*). See [Troubleshooting](troubleshooting.md) for further information.
 
 4. Start *Fourier Rewind* and behold the wondrously lime splash screen. Magical.
 

--- a/docs/legacy/rewind/manual/overview.md
+++ b/docs/legacy/rewind/manual/overview.md
@@ -6,16 +6,16 @@ sidebar_position: 3
 ![Main Screenshot](/img/rewind/overview-screenshot.png)
 
 So, what have we here? The interface is split into three key parts:
-1. At the **top left**, the [Time Control Region](time-control-region),
-1. At the **top right** the [RTA Region](rta-region),
-1. and at the **bottom**, the [Channel Selection Region](channel-selection-region).
+1. At the **top left**, the [Time Control Region](time-control-region.md),
+1. At the **top right** the [RTA Region](rta-region.md),
+1. and at the **bottom**, the [Channel Selection Region](channel-selection-region.md).
 
 Note that the RTA Region will only appear if you have a professional or production license
 
 In the top right-hand corner there are two buttons that open:
 
-1. ![Configuration Pane](/img/rewind/ui-cog.png) The [configuration pane](configuration-pane).
-1. ![Edit Pane](/img/rewind/ui-edit-pencil.png) The [channel edit pane](channel-edit-pane).
+1. ![Configuration Pane](/img/rewind/ui-cog.png) The [configuration pane](configuration-pane.md).
+1. ![Edit Pane](/img/rewind/ui-edit-pencil.png) The [channel edit pane](channel-edit-pane.md).
 
 In the application **File menu**, you'll find options to allow you to load and save your
-[showfile](showfiles), as well as to quit *Rewind* (but why would you want to do that?).
+[showfile](showfiles.md), as well as to quit *Rewind* (but why would you want to do that?).

--- a/docs/legacy/rewind/manual/troubleshooting.md
+++ b/docs/legacy/rewind/manual/troubleshooting.md
@@ -10,7 +10,7 @@ The following error may be shown on start up if Rewind fails to load due to to a
 
 ![Audio Configuration Error](/img/rewind/audio-config-error.png)
 
-This occurs when the Jack server has failed to load with either the selected, or default (if starting Rewind for the first time) audio IO and sample rate (as configured in the [configuration pane](configuration-pane)).
+This occurs when the Jack server has failed to load with either the selected, or default (if starting Rewind for the first time) audio IO and sample rate (as configured in the [configuration pane](configuration-pane.md)).
 
 By selecting 'No!! Go away.', Rewind will quit.
 
@@ -18,4 +18,4 @@ By selecting 'Yes please', Rewind will restart with the default system audio IO 
 
 When loading with the default devices, Rewind may create an aggregate device if necessary (ie. if the default audio input device is different to the output device). Therefore both the default input and output devices must run at the same sample rate or Rewind will fail to start.
 
-Should Rewind continue to fail to start after selecting 'Yes please', select the system's local IO as the default device (in macOS *System Preferences*), and then once Rewind has successfully launched, select your desired configuration in the [configuration pane](configuration-pane). The system default can then be reverted to your preference.
+Should Rewind continue to fail to start after selecting 'Yes please', select the system's local IO as the default device (in macOS *System Preferences*), and then once Rewind has successfully launched, select your desired configuration in the [configuration pane](configuration-pane.md). The system default can then be reverted to your preference.

--- a/docs/manual/getting-started.md
+++ b/docs/manual/getting-started.md
@@ -23,7 +23,7 @@ Be sure to read diligently the important information in the safety instructions!
 
 # Step 2: Plug it in
 
-Start by plugging in the network connections to a Dante network. To see some of the various options for network configuration, check out our handy manual page [here](installation/dante-network-examples).
+Start by plugging in the network connections to a Dante network. To see some of the various options for network configuration, check out our handy manual page [here](installation/dante-network-examples.md).
 
 Next, take your IEC cable and plug it into the **transform**.engine, and turn the power switch on.
 Wait for the engine to start: this may take a couple of minutes.
@@ -47,7 +47,7 @@ In order for the audio engine to start (enabling you to install, open and plugin
 
 :::warning
 
-Please note that at this time, the **transform**.client must be connected by either a static or DHCP IP address - **not link-local**; see [known issue TF-1686](./known-issues).
+Please note that at this time, the **transform**.client must be connected by either a static or DHCP IP address - **not link-local**; see [known issue TF-1686](known-issues.md).
 This will be resolved in a future release.
 
 :::
@@ -61,7 +61,7 @@ On your Windows or macOS computer (that you have connected to your **transform**
 
 # Step 5: Install the **transform**.client software
 
-Download the latest version of the **transform**.client software [here](../downloads).
+Download the latest version of the **transform**.client software [here](../downloads/index.md).
 
 Then install the **transform**.client software onto your computer following the Installer instructions.
 

--- a/docs/manual/installation/audio-setup.md
+++ b/docs/manual/installation/audio-setup.md
@@ -7,7 +7,7 @@ sidebar_label: Audio Configuration
 
 As the **transform**.engine uses Dante, the principal audio configuration options can be found in Dante Controller.
 
-When running Dante Controller (for further details on where to find the latest version, click [here](dante)), firstly click on the **transform**.engine that you wish to configure, and then select the "Device Config" tab.
+When running Dante Controller (for further details on where to find the latest version, click [here](dante.md)), firstly click on the **transform**.engine that you wish to configure, and then select the "Device Config" tab.
 
 There you are able to set the sample rate of that **transform**.engine, as well as the sample encoding and Dante network latency.
 
@@ -54,4 +54,4 @@ Available period sizes are:
 - 32 samples (1 ms internal latency at 96 kHz)
 - 64 samples (2 ms internal latency at 96 kHz)
 
-The buffer size can be configured in the **transform**.client software, with details available [here](../transform.client/system/system-status).
+The buffer size can be configured in the **transform**.client software, with details available [here](../transform.client/system/system-status.md).

--- a/docs/manual/installation/dante.md
+++ b/docs/manual/installation/dante.md
@@ -57,11 +57,11 @@ Ethernet network to use **transform**.engine; `100BASE-T` (IEEE 802.3u) networks
 :::warning
 
 Please note that at this time, the Secondary network must be configured to use **Static** or
-**DHCP** addressing for Dante Redundancy support; see [known issue TF-944](../known-issues).
+**DHCP** addressing for Dante Redundancy support; see [known issue TF-944](../known-issues.md).
 Link-local Dante Secondary will be supported in a future release.
 
 :::
 
-Example system configurations can be found [here!](dante-network-examples)
+Example system configurations can be found [here!](dante-network-examples.md)
 
 For further information about Dante network settings and support, please visit: https://www.audinate.com/support

--- a/docs/manual/installation/installation.md
+++ b/docs/manual/installation/installation.md
@@ -16,11 +16,11 @@ You will need:
 ### Configuring the IP address of the **transform**.engine
 
 Using the OLED display on the front of the unit, you can configure the IP address for the Dante Control, Primary and Secondary connections.
-For more details on this, see [here](../transform.engine/oled).
+For more details on this, see [here](../transform.engine/oled.md).
 
 :::warning
 
-Please note that at this time, the **transform**.client must be connected by either a static or DHCP IP address - **not link-local**; see [known issue TF-1686](../known-issues).
+Please note that at this time, the **transform**.client must be connected by either a static or DHCP IP address - **not link-local**; see [known issue TF-1686](../known-issues.md).
 This will be resolved in a future release.
 
 :::

--- a/docs/manual/transform.client/home/chains.md
+++ b/docs/manual/transform.client/home/chains.md
@@ -36,7 +36,7 @@ Five different states of your plugins:
 
 5. <img src={pluginfailed} alt="Plugin status - failed icon" width="100" /> **Failed**- The system has tried to get this plugin to start but has failed. Try using the 'Test Run' feature in Add/Remove plugins.
 
-Whilst in the top tool bar, you'll see a 'DSP load' bar, to give you a live indication of how much processing power is being used by your plugins. For a more detailed look, click on it and you will be taken to the [Performance](../system/performance) tab.
+Whilst in the top tool bar, you'll see a 'DSP load' bar, to give you a live indication of how much processing power is being used by your plugins. For a more detailed look, click on it and you will be taken to the [Performance](../system/performance.md) tab.
 
 ![Home tab with 6 chains](/img/transformclient/home-chains.png)
 

--- a/docs/manual/transform.client/library/plugins/ilok.md
+++ b/docs/manual/transform.client/library/plugins/ilok.md
@@ -14,7 +14,7 @@ As the Windows environment cannot access the internet, iLok protected plugins mu
 
 A number of plugin manufacturers use iLok for plugin licensing. We've put a guide below to get you up to speed.
 
-For plugin manufacturer specific licensing, find them [here](manufacturers).
+For plugin manufacturer specific licensing, find them [here](manufacturers/index.md).
 
 How to license your **iLok** protected plugins on the **transform**.engine:
 

--- a/docs/manual/transform.client/library/plugins/manufacturers/eventide.md
+++ b/docs/manual/transform.client/library/plugins/manufacturers/eventide.md
@@ -10,19 +10,19 @@ How to install **Eventide** plugins on your **transform**.engine!
 
 **Plugin Download Link:** [Eventide Plugins](https://www.eventideaudio.com/downloads/)
 
-**Licensing Method:** iLok ([Licensing Guide](../ilok))
+**Licensing Method:** iLok ([Licensing Guide](../ilok.md))
 
 **Plugin Format:** Windows VST3
 
 **Installer File Format:** `.exe`
 
-1. After following the [Accessing Windows steps](../installation#accessing-windows-to-install-plugins), you will be in a position to install plugins.
+1. After following the [Accessing Windows steps](../installation.md#accessing-windows-to-install-plugins), you will be in a position to install plugins.
 2. On your personal device, download the desired plugin(s) for a Windows OS from the above link, it should be in a `.exe` file format.
 3. Copy this installer file to a USB stick.
 4. Plug it into any of the USB ports on the **transform**.engine.
 5. In the search bar, type ‘This PC’, it will find the ‘This PC’ app and hit enter.
 6. Locate your USB stick in the window and find your Eventide installer file.
-7. Run the Application (`.exe` file) for the desired plugin.
+7. Run the Application (`.exe file) for the desired plugin.
 8. During the installation process, when asked which components to install, unselect AAX and VST.
 9. Install location does not need to be altered.
 10. Navigate through each menu, and once complete, click ‘Finish’.

--- a/docs/manual/transform.client/library/plugins/manufacturers/fabfilter.md
+++ b/docs/manual/transform.client/library/plugins/manufacturers/fabfilter.md
@@ -10,13 +10,13 @@ How to install **FabFilter** plugins on your **transform**.engine!
 
 **Plugin Download Link:** [FabFilter Plugins](https://www.fabfilter.com/download)
 
-**Licensing Method:** Proprietary, run 'Test Run Plugin' to provide file ([Licensing Guide](../test-run))
+**Licensing Method:** Proprietary, run 'Test Run Plugin' to provide file ([Licensing Guide](../test-run.md))
 
 **Plugin Format:** Windows VST3
 
 **Installer File Format:** `.exe`
 
-1. After following the [Accessing Windows steps](../installation#accessing-windows-to-install-plugins), you will be in a position to install plugins.
+1. After following the [Accessing Windows steps](../installation.md#accessing-windows-to-install-plugins), you will be in a position to install plugins.
 2. On your personal device, download the desired plugin(s) for a Windows OS from the above link, it should be in a `.exe` file format.
 3. Copy this installer file to a USB stick.
 4. Plug it into any of the USB ports on the **transform**.engine.

--- a/docs/manual/transform.client/library/plugins/manufacturers/kazrog.md
+++ b/docs/manual/transform.client/library/plugins/manufacturers/kazrog.md
@@ -10,13 +10,13 @@ How to install **Kazrog** plugins on your **transform**.engine!
 
 **Plugin Download Link:** [Kazrog Plugins](https://kazrog.com/collections/audio-plugins)
 
-**Licensing Method:** iLok ([Licensing Guide](../ilok))
+**Licensing Method:** iLok ([Licensing Guide](../ilok.md)
 
 **Plugin Format:** Windows VST3
 
 **Installer File Format:** `.exe`
 
-1. After following the [Accessing Windows steps](../installation#accessing-windows-to-install-plugins), you will be in a position to install plugins.
+1. After following the [Accessing Windows steps](../installation.md#accessing-windows-to-install-plugins), you will be in a position to install plugins.
 2. On your personal device, download the desired plugin(s) for a Windows OS from the above link, it should be in a `.exe` file format.
 3. Copy this installer file to a USB stick.
 4. Plug it into any of the USB ports on the **transform**.engine.

--- a/docs/manual/transform.client/library/plugins/manufacturers/krotos-audio.md
+++ b/docs/manual/transform.client/library/plugins/manufacturers/krotos-audio.md
@@ -10,13 +10,13 @@ How to install **Krotos Audio** plugins on your **transform**.engine!
 
 **Plugin Download Link:** [Krotos Audio Plugins](https://www.krotosaudio.com/)
 
-**Licensing Method:** iLok ([Licensing Guide](../ilok))
+**Licensing Method:** iLok ([Licensing Guide](../ilok.md)
 
 **Plugin Format:** Windows VST3
 
 **Installer File Format:** `.exe`
 
-1. After following the [Accessing Windows steps](../installation#accessing-windows-to-install-plugins), you will be in a position to install plugins.
+1. After following the [Accessing Windows steps](../installation.md#accessing-windows-to-install-plugins), you will be in a position to install plugins.
 2. On your personal device, download the desired plugin(s) for a Windows OS from the above link, it should be in a `.exe` file format.
 3. Copy this installer file to a USB stick.
 4. Plug it into any of the USB ports on the **transform**.engine.

--- a/docs/manual/transform.client/library/plugins/manufacturers/mcdsp.md
+++ b/docs/manual/transform.client/library/plugins/manufacturers/mcdsp.md
@@ -10,7 +10,7 @@ How to install **McDSP** plugins on your **transform**.engine!
 
 **Plugin Download Link:** [McDSP Plugins](https://mcdsp.com/downloads/plugin-downloads/#Plug-ins)
 
-**Licensing Method:** iLok ([Licensing Guide](../ilok))
+**Licensing Method:** iLok ([Licensing Guide](../ilok.md)
 
 **Plugin Format:** Windows VST3
 
@@ -18,7 +18,7 @@ How to install **McDSP** plugins on your **transform**.engine!
 
 **Method 1- Individual**
 
-1. After following the [Accessing Windows steps](../installation#accessing-windows-to-install-plugins), you will be in a position to install plugins.
+1. After following the [Accessing Windows steps](../installation.md#accessing-windows-to-install-plugins), you will be in a position to install plugins.
 2. On your personal device, download the desired plugin(s) for a Windows OS from the above link, it should be in a `.exe` file format.
 3. Copy this installer file to a USB stick.
 4. Plug it into any of the USB ports on the **transform**.engine.
@@ -31,7 +31,7 @@ How to install **McDSP** plugins on your **transform**.engine!
 
 **Method 2- Bundle**
 
-1. After following the [Accessing Windows steps](../installation#accessing-windows-to-install-plugins), you will be in a position to install plugins.
+1. After following the [Accessing Windows steps](../installation.md#accessing-windows-to-install-plugins), you will be in a position to install plugins.
 2. On your personal device, download the desired plugin bundle for a Windows OS from the above link, it should be in a .zip file format.
 3. Unzip the downloaded file, this will present an installer `.exe` file format.
 4. Copy this installer folder to a USB stick.

--- a/docs/manual/transform.client/library/plugins/manufacturers/oeksound.md
+++ b/docs/manual/transform.client/library/plugins/manufacturers/oeksound.md
@@ -10,13 +10,13 @@ How to install **oeksound** plugins on your **transform**.engine!
 
 **Plugin Download Link:** [oeksound Plugins](https://oeksound.com/downloads/)
 
-**Licensing Method:** iLok ([Licensing Guide](../ilok))
+**Licensing Method:** iLok ([Licensing Guide](../ilok.md)
 
 **Plugin Format:** Windows VST3
 
 **Installer File Format:** `.exe`
 
-1. After following the [Accessing Windows steps](../installation#accessing-windows-to-install-plugins), you will be in a position to install plugins.
+1. After following the [Accessing Windows steps](../installation.md#accessing-windows-to-install-plugins), you will be in a position to install plugins.
 2. On your personal device, download the desired plugin(s) for a Windows OS from the above link, it should be in a `.exe` file format.
 3. Copy this installer file to a USB stick.
 4. Plug it into any of the USB ports on the **transform**.engine.

--- a/docs/manual/transform.client/library/plugins/manufacturers/plugin-alliance.md
+++ b/docs/manual/transform.client/library/plugins/manufacturers/plugin-alliance.md
@@ -20,7 +20,7 @@ How to install and license **Plugin Alliance** plugins on your **transform**.eng
 
 **Method 1- Individual**
 
-1. After following the [Accessing Windows steps](../installation#accessing-windows-to-install-plugins), you will be in a position to install plugins.
+1. After following the [Accessing Windows steps](../installation.md#accessing-windows-to-install-plugins), you will be in a position to install plugins.
 2. On your personal device, download the desired plugin(s) for a Windows OS from the above link, it should be in a `.exe` file format.
 3. Copy this installer file to a USB stick.
 4. Plug it into any of the USB ports on the **transform**.engine.

--- a/docs/manual/transform.client/library/plugins/manufacturers/psp-audioware.md
+++ b/docs/manual/transform.client/library/plugins/manufacturers/psp-audioware.md
@@ -10,13 +10,13 @@ How to install **PSP Audioware** plugins on your **transform**.engine!
 
 **Plugin Download Link:** [PSP Audioware Plugins](https://www.pspaudioware.net/UserArea/demos)
 
-**Licensing Method:** iLok ([Licensing Guide](../ilok))
+**Licensing Method:** iLok ([Licensing Guide](../ilok.md)
 
 **Plugin Format:** Windows VST3
 
 **Installer File Format:** `.exe`
 
-1. After following the [Accessing Windows steps](../installation#accessing-windows-to-install-plugins), you will be in a position to install plugins.
+1. After following the [Accessing Windows steps](../installation.md#accessing-windows-to-install-plugins), you will be in a position to install plugins.
 2. On your personal device, download the desired plugin(s) for a Windows OS from the above link, it should be in a `.exe` file format.
 3. Copy this installer file to a USB stick.
 4. Plug it into any of the USB ports on the **transform**.engine.

--- a/docs/manual/transform.client/library/plugins/manufacturers/slate-digital.md
+++ b/docs/manual/transform.client/library/plugins/manufacturers/slate-digital.md
@@ -10,13 +10,13 @@ How to install **Slate Digital** plugins on your **transform**.engine!
 
 **Plugin Download Link:** [Slate Digital](https://app.completeaccess.audio/installers)
 
-**Licensing Method:** iLok ([Licensing Guide](../ilok))
+**Licensing Method:** iLok ([Licensing Guide](../ilok.md)
 
 **Plugin Format:** Windows VST3
 
 **Installer File Format:** `.exe`
 
-1. After following the [Accessing Windows steps](../installation#accessing-windows-to-install-plugins), you will be in a position to install plugins.
+1. After following the [Accessing Windows steps](../installation.md#accessing-windows-to-install-plugins), you will be in a position to install plugins.
 2. On your personal device, download the desired plugin(s) for a Windows OS from the above link, it should be in a `.exe` file format.
 3. Copy this installer file to a USB stick.
 4. Plug it into any of the USB ports on the **transform**.engine.

--- a/docs/manual/transform.client/library/plugins/manufacturers/softube.md
+++ b/docs/manual/transform.client/library/plugins/manufacturers/softube.md
@@ -10,13 +10,13 @@ How to install **Softube** plugins on your **transform**.engine.
 
 **Plugin Download Link:** [Softube Plugins](https://www.softube.com/installer-windows)
 
-**Licensing Method:** iLok ([Licensing Guide](../ilok))
+**Licensing Method:** iLok ([Licensing Guide](../ilok.md)
 
 **Plugin Format:** Windows VST3
 
 **Installer File Format:** `.exe`
 
-1. After following the [Accessing Windows steps](../installation#accessing-windows-to-install-plugins), you will be in a position to install plugins.
+1. After following the [Accessing Windows steps](../installation.md#accessing-windows-to-install-plugins), you will be in a position to install plugins.
 2. On your personal device, download the desired plugin(s) for a Windows OS from the above link, it should be in a `.exe` file format.
 3. Copy this installer file to a USB stick.
 4. Plug it into any of the USB ports on the **transform**.engine.

--- a/docs/manual/transform.client/library/plugins/manufacturers/sonnox.md
+++ b/docs/manual/transform.client/library/plugins/manufacturers/sonnox.md
@@ -10,13 +10,13 @@ How to install **Sonnox** plugins on your **transform**.engine!
 
 **Plugin Download Link:** [Sonnox Plugins](https://www.sonnox.com/installers)
 
-**Licensing Method:** iLok ([Licensing Guide](../ilok))
+**Licensing Method:** iLok ([Licensing Guide](../ilok.md)
 
 **Plugin Format:** Windows VST3
 
 **Installer File Format:** `.exe`
 
-1. After following the [Accessing Windows steps](../installation#accessing-windows-to-install-plugins), you will be in a position to install plugins.
+1. After following the [Accessing Windows steps](../installation.md#accessing-windows-to-install-plugins), you will be in a position to install plugins.
 2. On your personal device, download the desired plugin(s) for a Windows OS from the above link, it should be in a `.exe` file format.
 3. Copy this installer file to a USB stick.
 4. Plug it into any of the USB ports on the **transform**.engine.

--- a/docs/manual/transform.client/library/plugins/manufacturers/sound-theory.md
+++ b/docs/manual/transform.client/library/plugins/manufacturers/sound-theory.md
@@ -10,13 +10,13 @@ How to install **Sound Theory** plugins on your **transform**.engine!
 
 **Plugin Download Link:** [Sound Theory Plugins](https://www.soundtheory.com/support)
 
-**Licensing Method:** iLok ([Licensing Guide](../ilok))
+**Licensing Method:** iLok ([Licensing Guide](../ilok.md)
 
 **Plugin Format:** Windows VST3
 
 **Installer File Format:** `.zip`
 
-1. After following the [Accessing Windows steps](../installation#accessing-windows-to-install-plugins), you will be in a position to install plugins.
+1. After following the [Accessing Windows steps](../installation.md#accessing-windows-to-install-plugins), you will be in a position to install plugins.
 2. On your personal device, download the desired plugin(s) for a Windows OS from the above link, it should be in a `.zip` file format.
 3. Unzip it, and copy the `.exe` installer file to a USB stick.
 4. Plug it into any of the USB ports on the **transform**.engine.

--- a/docs/manual/transform.client/library/plugins/manufacturers/soundtoys.md
+++ b/docs/manual/transform.client/library/plugins/manufacturers/soundtoys.md
@@ -10,13 +10,13 @@ How to install **Soundtoys** plugins on your **transform**.engine.
 
 **Plugin Download Link:** [Soundtoys](https://storage.googleapis.com/soundtoys-download/download.html)
 
-**Licensing Method:** iLok ([Licensing Guide](../ilok))
+**Licensing Method:** iLok ([Licensing Guide](../ilok.md)
 
 **Plugin Format:** Windows VST3
 
 **Installer File Format:** `.exe`
 
-1. After following the [Accessing Windows steps](../installation#accessing-windows-to-install-plugins), you will be in a position to install plugins.
+1. After following the [Accessing Windows steps](../installation.md#accessing-windows-to-install-plugins), you will be in a position to install plugins.
 2. On your personal device, download the desired plugin(s) for a Windows OS from the above link, it should be in a `.exe` file format.
 3. Copy this installer file to a USB stick.
 4. Plug it into any of the USB ports on the **transform**.engine.

--- a/docs/manual/transform.client/library/plugins/manufacturers/ssl.md
+++ b/docs/manual/transform.client/library/plugins/manufacturers/ssl.md
@@ -10,13 +10,13 @@ How to install **Solid State Logic** plugins on your **transform**.engine!
 
 **Plugin Download Link:** [SSL Plugins](https://support.solidstatelogic.com/hc/en-gb/articles/4849510029085-SSL-and-Harrison-Plug-in-Downloads#ssl-and-harrison-plug-in-downloads-0-0)
 
-**Licensing Method:** iLok ([Licensing Guide](../ilok))
+**Licensing Method:** iLok ([Licensing Guide](../ilok.md)
 
 **Plugin Format:** Windows VST3
 
 **Installer File Format:** `.exe`
 
-1. After following the [Accessing Windows steps](../installation#accessing-windows-to-install-plugins), you will be in a position to install plugins.
+1. After following the [Accessing Windows steps](../installation.md#accessing-windows-to-install-plugins), you will be in a position to install plugins.
 2. On your personal device, download the desired plugin(s) for a Windows OS from the above link, it should be in a `.exe` file format.
 3. Copy this installer file to a USB stick.
 4. Plug it into any of the USB ports on the **transform**.engine.

--- a/docs/manual/transform.client/library/plugins/manufacturers/tc-electronic.md
+++ b/docs/manual/transform.client/library/plugins/manufacturers/tc-electronic.md
@@ -10,13 +10,13 @@ How to install **TC Electronic** plugins on your **transform**.engine!
 
 **Plugin Download Link:** [TC Electronic](https://store.tcelectronic.com/)
 
-**Licensing Method:** iLok ([Licensing Guide](../ilok))
+**Licensing Method:** iLok ([Licensing Guide](../ilok.md)
 
 **Plugin Format:** Windows VST3
 
 **Installer File Format:** `.msi`
 
-1. After following the [Accessing Windows steps](../installation#accessing-windows-to-install-plugins), you will be in a position to install plugins.
+1. After following the [Accessing Windows steps](../installation.md#accessing-windows-to-install-plugins), you will be in a position to install plugins.
 2. On your personal device, download the desired plugin(s) for a Windows OS from the above link, it should be in a `.msi` file format.
 3. Copy this installer file to a USB stick.
 4. Plug it into any of the USB ports on the **transform**.engine.

--- a/docs/manual/transform.client/library/plugins/manufacturers/valhalla.md
+++ b/docs/manual/transform.client/library/plugins/manufacturers/valhalla.md
@@ -10,13 +10,13 @@ How to install and license **Valhalla** plugins on your **transform**.engine!
 
 **Plugin Download Link:** [Valhalla Plugins](https://valhalladsp.com/plugins/)
 
-**Licensing Method:** Proprietary, run 'Test Plugin' to provide file ([Licensing Guide](../test-run))
+**Licensing Method:** Proprietary, run 'Test Plugin' to provide file ([Licensing Guide](../test-run.md))
 
 **Plugin Format:** Windows VST3
 
 **Installer File Format:** `.exe`
 
-1. After following the [Accessing Windows steps](../installation#accessing-windows-to-install-plugins), you will be in a position to install plugins.
+1. After following the [Accessing Windows steps](../installation.md#accessing-windows-to-install-plugins), you will be in a position to install plugins.
 2. On your personal device, download the desired plugin(s) for a Windows OS from the above link, it should be in a `.exe` file format.
 3. Copy this installer file to a USB stick.
 4. Plug it into any of the USB ports on the **transform**.engine.

--- a/docs/manual/transform.client/library/plugins/manufacturers/waves.md
+++ b/docs/manual/transform.client/library/plugins/manufacturers/waves.md
@@ -24,7 +24,7 @@ When scanning for newly installed Waves Plugins, the **transform**.client may in
 
 :::
 
-1. After following the [Accessing Windows steps](../installation#accessing-windows-to-install-plugins), you will be in a position to install plugins.
+1. After following the [Accessing Windows steps](../installation.md#accessing-windows-to-install-plugins), you will be in a position to install plugins.
 2. On your personal device, download Waves Central using the link above.
 3. Once installed, launch Waves Central and log into your Waves account.
 4. Select 'Offline Installer', and then 'My Products'.

--- a/docs/manual/transform.client/transform.client.md
+++ b/docs/manual/transform.client/transform.client.md
@@ -11,9 +11,9 @@ Deliberately designed to be simple, we want to get you up and running in next to
 
 Split into three tabs:
 
-1. Accessible at the top left: [**Home**](home) - Build your plugin chains.
-2. Next door to Home: [**Library**](library) - Your toolbox, add and remove plugins.
-3. Top right corner: [**System**](system/showfiles) - allows you to set up your show, and get under the hood of your **transform**.engine.
+1. Accessible at the top left: [**Home**](home/home.md) - Build your plugin chains.
+2. Next door to Home: [**Library**](library/library.md) - Your toolbox, add and remove plugins.
+3. Top right corner: [**System**](system/showfiles.md) - allows you to set up your show, and get under the hood of your **transform**.engine.
 
 ### Connecting to your **transform**.engine.
 
@@ -25,7 +25,7 @@ And voila, you're in!
 
 :::warning
 
-Please note that at this time, the **transform**.client must be connected by either a static or DHCP IP address - **not link-local**; see [known issue TF-1686](../known-issues).
+Please note that at this time, the **transform**.client must be connected by either a static or DHCP IP address - **not link-local**; see [known issue TF-1686](../known-issues.md).
 This will be resolved in a future release.
 
 :::

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,6 +7,7 @@ module.exports = {
   tagline: "",
   url: "https://docs.fourieraudio.com",
   baseUrl: "/",
+  trailingSlash: true,
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
   markdown: {


### PR DESCRIPTION
This commit configures `docusaurus` to use an explicit `trailingSlash` configuration. Without this configuration, a file `doc.md` would be rendered as `doc/index.html`, but docusaurus would accept links to it as `/doc`. When such a link was served by `nginx`, it would automatically (and correctly) perform a redirect to `/doc/`, as once rendered, the user is requesting a directory. However, when such a link was processed by the in-javascript loading, docusaurus would fail to resolve the file and return an error.

This commit moves us to using the more strict `trailingSlash: true` mode, meaning that links are always emitted in the form containing a trailing slash. I did consider using `trailingSlash: false`, but this would result in `doc.md` being rendered as `doc.html`, and we would rather not have the file extension in URLs and avoiding the need for URL rewrite helps keep the server config simple. Because of this move, a number of the internal links within the documentation which linked to URLs, rather than to specific documents, are now detected as invalid by docusaurus during the build. This commit therefore also fixes those links to refer to the origin documents, allowing docusuarus to resolve and rewrite them successfully.

The link rewriting was performed via judicious application of `sed` and the results have
been tested locally.