### PR TITLE
`/support`: Fix broken inter-doc links

### DIFF
--- a/docs/support.mdx
+++ b/docs/support.mdx
@@ -11,13 +11,13 @@ Welcome to the **transform**.engine support site. Here you can find the manual f
 
 All of the commonly asked questions regarding the **transform**.engine can be found here:
 
-<a class="button button--lg button--primary" href="manual/tech-faqs">Transform FAQs</a>
+<a class="button button--lg button--primary" href="/manual/tech-faqs">Transform FAQs</a>
 
 ## Getting Started
 
 For help getting started with your **transform**.engine, check out our handy getting started guide, complete with fun videos:
 
-<a class="button button--lg button--primary" href="manual/getting-started">Getting Started Guide</a>
+<a class="button button--lg button--primary" href="/manual/getting-started">Getting Started Guide</a>
 
 ## Discourse
 


### PR DESCRIPTION
On the support page, we use some HTML `a` tags styled as buttons, which it seems docusaurus doesn't validate for broken links on build. Consequently, they accidentally became broken. This commit fixes this in a sticking-plaster fashion. We should consider migrating these buttons to being of a form that can be statically checked by docusaurus.