### PR TITLE
TF-2245: Release transform.engine v1.2.1

### DIFF
--- a/info/downloads/index.md
+++ b/info/downloads/index.md
@@ -6,11 +6,11 @@ sidebar_position: 4
 
 Here you can find the latest **transform**.client:
 
-<a class="button button--lg button--primary" href="https://downloads.fourieraudio.com/transform/latest/FourierTransform-Release-1.2.0-win32.exe">Windows v1.2.0</a>
+<a class="button button--lg button--primary" href="https://downloads.fourieraudio.com/transform/latest/FourierTransform-Release-1.2.1-win32.exe">Windows v1.2.1</a>
 <br/><br/>
-<a class="button button--lg button--primary" href="https://downloads.fourieraudio.com/transform/latest/FourierTransform-Release-1.2.0-arm64.zip">macOS (ARM) v1.2.0</a>
+<a class="button button--lg button--primary" href="https://downloads.fourieraudio.com/transform/latest/FourierTransform-Release-1.2.1-arm64.zip">macOS (ARM) v1.2.1</a>
 <br/><br/>
-<a class="button button--lg button--primary" href="https://downloads.fourieraudio.com/transform/latest/FourierTransform-Release-1.2.0-x64.zip">macOS (x86-64) v1.2.0</a>
+<a class="button button--lg button--primary" href="https://downloads.fourieraudio.com/transform/latest/FourierTransform-Release-1.2.1-x64.zip">macOS (x86-64) v1.2.1</a>
 <br/><br/>
 
 :::info
@@ -35,7 +35,8 @@ compatibility ranges at any time.</small>
 
 | Engine Version | Client Version            | Release Date | Latest  |                      |
 | -------------- | ------------------------- | ------------ | ------- | -------------------- |
-| 1.2.0          | **1.2.0**                 | 30/08/2024   | **Yes** | [Release notes](v1-2-0.md) |
+| **1.2.1**      | **1.2.1**                 | 04/09/2024   | **Yes** | [Release notes](v1-2-1.md) |
+| 1.2.0          | 1.2.0                     | 30/08/2024   |         | [Release notes](v1-2-0.md) |
 |                | 1.1.1                     | 04/07/2024   |         | [Release notes](v1-1-1.md) |
 | 1.1.0          | 1.1.0                     | 24/06/2024   |         | [Release notes](v1-1-0.md) |
 |                | 1.0.1                     | 22/04/2024   |         | [Release notes](v1-0-1.md) |

--- a/info/downloads/v1-2-1.md
+++ b/info/downloads/v1-2-1.md
@@ -1,0 +1,65 @@
+---
+sidebar_label: Release Notes v1.2.1
+---
+
+# transform.engine v1.2.1 release notes
+
+- **Engine Version**: `1.2.1`
+- **Windows Client Version**: `1.2.1`
+- **macOS Client Version**: `1.2.1`
+
+## Summary
+
+This is a bugfix **transform**.engine and **transform**.client patch release; for details of the
+newest improvements, see
+[v1.2.0](v1-2-0.md)!
+
+## Bugs Fixed In This Release
+
+1. **TF-2245: engine upgrade fails when updating factory-fresh units**
+
+  We discovered that in v1.2.0, the upgrade system had inadvertently omitted two component packages
+  which are required to upgrade a factory-fresh engine to a v1.0+ release. Upgraders for v1.0 and
+  v1.1 included the packages in question, but due to a bug the v1.2 upgrade did not. This meant
+  that units previously running v1.0 or v1.1 could upgrade to v1.2 without issue, but units on
+  older versions could not. This v1.2.1 release now includes the missing packages.
+
+We recommend that all users upgrade to this release.
+
+## Compatibility Notes
+This release introduces no compatibility changes from [v1.2.0](v1-2-0.md).
+
+## Known Issues
+
+Users should be aware of the following [known issues](/manual/known-issues) in this release, which
+we hope to address in a future update:
+
+- TF-1891: DSP load meter can occasionally jump to 100% load, before returning to normal. We believe
+  these occasional jumps are spurious and can be safely ignored.
+- TF-2148: When **transform**.engine is the PTP clock leader, changing the sample rate from 96 kHz
+  to 48 kHz in Dante Controller can result in the Dante audio transport stalling if transform.engine
+  is the PTP clock leader. Restarting the **transform**.engine after changing sample rate resolves
+  the issue.
+
+For more details and workarounds for these issues, see the [known issues list](/manual/known-issues).
+
+A small number of plugins may experience compatibility issues running on transform.engine.
+For details, see our plugin compatibility database at https://plugins.fourieraudio.com .
+
+## Docs, Support & Bug Requests
+
+We would warmly welcome any bug reports you may have on our discussion site:
+https://discourse.fourieraudio.com . We’ll also be happy to chat and answer any questions you may
+have there!
+
+To learn more about how to use transform.engine, please check out our docs at
+https://docs.fourieraudio.com , where you can also find handy walkthrough videos showing how to get
+started.
+
+If you need support with transform.engine, please feel free to reach out to your local dealer or
+distributor, or contact us directly at support@fourieraudio.com .
+
+## Upcoming Release Schedule
+
+We are hoping to release transform.engine v1.3 later this year. For information on what’s
+coming up, see our product roadmap here: https://go.fourieraudio.com/future .


### PR DESCRIPTION
This commit updates the documentation to release v1.2.1 of the transform.engine software.