### PR TITLE
TF-2723: Release transform.client v1.3.1

### DIFF
--- a/info/downloads/index.md
+++ b/info/downloads/index.md
@@ -6,11 +6,11 @@ sidebar_position: 4
 
 Here you can find the latest **transform**.client:
 
-<a class="button button--lg button--primary" href="https://downloads.fourieraudio.com/transform/latest/FourierTransform-Release-1.3.0-win32.exe">Windows v1.3.0</a>
+<a class="button button--lg button--primary" href="https://downloads.fourieraudio.com/transform/latest/FourierTransform-Release-1.3.1-win32.exe">Windows v1.3.1</a>
 <br/><br/>
-<a class="button button--lg button--primary" href="https://downloads.fourieraudio.com/transform/latest/FourierTransform-Release-1.3.0-arm64.zip">macOS (ARM) v1.3.0</a>
+<a class="button button--lg button--primary" href="https://downloads.fourieraudio.com/transform/latest/FourierTransform-Release-1.3.1-arm64.zip">macOS (ARM) v1.3.1</a>
 <br/><br/>
-<a class="button button--lg button--primary" href="https://downloads.fourieraudio.com/transform/latest/FourierTransform-Release-1.3.0-x64.zip">macOS (x86-64) v1.3.0</a>
+<a class="button button--lg button--primary" href="https://downloads.fourieraudio.com/transform/latest/FourierTransform-Release-1.3.1-x64.zip">macOS (x86-64) v1.3.1</a>
 <br/><br/>
 
 :::info
@@ -42,7 +42,8 @@ compatibility ranges at any time.</small>
 
 | Engine Version | Client Version            | Release Date | Latest  |                      |
 | -------------- | ------------------------- | ------------ | ------- | -------------------- |
-| **1.3.0**      | **1.3.0**                 | 11/02/2025   | **Yes** | [Release notes](v1-3-0.md) |
+|                | **1.3.1**                 | 14/02/2025   | **Yes** | [Release notes](v1-3-1.md) |
+| **1.3.0**      | 1.3.0                     | 11/02/2025   |         | [Release notes](v1-3-0.md) |
 | 1.2.5          |                           | 25/11/2024   |         | [Release notes](v1-2-1.md) |
 | 1.2.1          | 1.2.1                     | 04/09/2024   |         | [Release notes](v1-2-1.md) |
 | 1.2.0          | 1.2.0                     | 30/08/2024   |         | [Release notes](v1-2-0.md) |

--- a/info/downloads/v1-3-1.md
+++ b/info/downloads/v1-3-1.md
@@ -1,0 +1,58 @@
+---
+sidebar_label: Release Notes v1.3.1
+---
+
+# transform.engine v1.3.1 release notes
+
+- **Engine Version**: `1.3.0`
+- **Windows Client Version**: `1.3.1`
+- **macOS Client Version**: `1.3.1`
+
+## Summary
+
+This is a bugfix **transform**.client patch release; for details of the newest
+improvements, see [v1.3.0](v1-3-0.md)!
+
+## Bugs Fixed In This Release
+
+1. **TF-2723: engine upgrade not offered for some factory-fresh units**
+
+  We discovered that in v1.3.0, **transform**.client would fail to offer the
+  mandatory upgrade for **transform**.engines delivered from the factory
+  running software versions v0.0.11 or v0.0.12 due to an issue with the
+  communication protocol used by those versions (only), preventing those
+  engines from being used.
+
+  This v1.3.1 release of **transform**.client resolves the issue, meaning that
+  all engines can be successfully upgraded. There is no change to the engine software
+  in this release, which remains at v1.3.0.
+
+We recommend that all users upgrade to this release.
+
+## Compatibility Notes
+This release introduces no compatibility changes from [v1.3.0](v1-3-0.md).
+
+## Known Issues
+
+Users should be aware of the following [known issues](/manual/known-issues) in this release, which
+we hope to address in a future update:
+
+- TF-2148: When **transform**.engine is the PTP clock leader on boot, changing the sample rate from 96 kHz to 48 kHz in Dante Controller can result in the Dante audio transport stalling. Restarting the **transform**.engine after changing sample rate resolves the issue.
+- TF-2698: When bx\_limiter or AMEK EQ 200 are used in a chain, recalling cues can cause a momentary increase in DSP load.
+
+For more details and workarounds for these issues, see the [known issues list](/manual/known-issues).
+
+A small number of plugins may experience compatibility issues running on transform.engine.
+For details, see our plugin compatibility database at https://plugins.fourieraudio.com .
+
+## Docs, Support & Bug Requests
+
+We would warmly welcome any bug reports you may have on our discussion site: [https://discourse.fourieraudio.com](https://discourse.fourieraudio.com) . We’ll also be happy to chat and answer any questions you may have there\!
+
+To learn more about how to use **transform**.engine, please check out our docs at [https://docs.fourieraudio.com](https://docs.fourieraudio.com) , where you can also find handy walkthrough videos showing how to get started.
+
+If you need support with **transform**.engine, please feel free to reach out to your local dealer or distributor, or contact us directly at [support@fourieraudio.com](mailto:support@fourieraudio.com) .
+
+## Upcoming Release Schedule
+
+We are hoping to release **transform**.engine v1.4 at the end of Q1 this year. For information on what’s coming up, see our feature horizon here: [https://go.fourieraudio.com/future](https://go.fourieraudio.com/future) .


### PR DESCRIPTION
This commit releases transform.client v1.3.1, to resolve an issue where some factory-fresh transform.engine units could not be upgraded.