### PR TITLE
Remove tyop from "Plugin Host Reset" section

### DIFF
--- a/manual/transform.client/system/reset.md
+++ b/manual/transform.client/system/reset.md
@@ -21,7 +21,7 @@ If you are looking to only delete one showfile, you can do so in the **Showfiles
 
 ### Plugin Host Reset
 
-This one is for special occasions only. Say you've just received a transform.engine that already has some plugins on it@site. This option will enable you to reset the Windows environment back to the factory default - i.e. it will uninstall **all** plugins from the **transform**.engine.
+This one is for special occasions only. Say you've just received a transform.engine that already has some plugins on it: this option will enable you to reset the Windows environment back to the factory default - i.e. it will uninstall **all** plugins from the **transform**.engine.
 
 :::danger
 


### PR DESCRIPTION
There was a spurious `@site` for some reason. Remove it.